### PR TITLE
raw2dng: Fix calibration frame cropping code to support images with a…

### DIFF
--- a/raw2dng/metadata.c
+++ b/raw2dng/metadata.c
@@ -100,6 +100,10 @@ int metadata_get_ystart(uint16_t registers[128])
 {
     return registers[2];
 }
+int metadata_get_ysize(uint16_t registers[128])
+{
+    return registers[34];
+}
 
 void metadata_dump_registers(uint16_t registers[128])
 {

--- a/raw2dng/metadata.h
+++ b/raw2dng/metadata.h
@@ -9,5 +9,6 @@ int metadata_get_gain(uint16_t registers[128]);
 int metadata_get_dark_offset(uint16_t registers[128]);
 double metadata_get_exposure(uint16_t registers[128]);
 int metadata_get_ystart(uint16_t registers[128]);
+int metadata_get_ysize(uint16_t registers[128]);
 
 #endif


### PR DESCRIPTION
Fix to allow cropped raws (for example if shooting 4096x2160 DCI resolution raw).